### PR TITLE
Don't assume PWD is the checkout root.

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -4,4 +4,5 @@ table.insert(package.loaders, fennel.make_searcher({correlate=true}))
 pp = function(x) print(require("lib.fennelview")(x)) end
 lume = require("lib.lume")
 
+fennel.path = love.filesystem.getSource() .. "/?.fnl"
 require("wrap")

--- a/world.fnl
+++ b/world.fnl
@@ -333,7 +333,7 @@
 ;; error out if either 'maps/${name}.png' or 'maps/${name}.fnl' do not exist.
 (fn new-world [name player]
   (let [tiles-path (.. "maps/" name ".png")
-        meta-path (.. "maps/" name ".fnl")
+        meta-path (.. (love.filesystem.getSource) "/maps/" name ".fnl")
         res (load-tiles (love.image.newImageData tiles-path))
         res (lume.extend res {:player player})
         res (lume.extend res {:slimeballs []})


### PR DESCRIPTION
The AppImage version of love2d changes to a temporary directory before
running, so you have to explicitly specify the full path; relative
paths won't be correct.

This won't fix the problem when running from a .love file; in that
case you would need to do AOT compilation and include the .lua output
inside the archive, but it's a start for folks running from source.